### PR TITLE
Story #47: Add `lastMessageAt` column to the `conversation` table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "connect-redis": "^7.1.1",
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
+        "dayjs": "^1.11.13",
         "dotenv": "^16.4.5",
         "express": "^4.21.0",
         "express-session": "^1.18.1",
@@ -1811,6 +1812,11 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg=="
     },
     "node_modules/debug": {
       "version": "2.6.9",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "connect-redis": "^7.1.1",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
+    "dayjs": "^1.11.13",
     "dotenv": "^16.4.5",
     "express": "^4.21.0",
     "express-session": "^1.18.1",

--- a/src/domain/dtos/conversation/ICreateConversationRequestDTO.ts
+++ b/src/domain/dtos/conversation/ICreateConversationRequestDTO.ts
@@ -1,6 +1,5 @@
-import { ConversationType } from "@domain/enums";
-
 export interface ICreateConversationRequestDTO {
   title?: string;
+  lastMessageAt?: Date;
   participants: string[];
 }

--- a/src/domain/entities/Conversation.ts
+++ b/src/domain/entities/Conversation.ts
@@ -10,6 +10,7 @@ export interface ConversationProps {
   deletedAt: Date;
   type: ConversationType;
   groupAvatar?: string;
+  lastMessageAt?: Date;
 }
 
 export class Conversation {
@@ -20,6 +21,7 @@ export class Conversation {
   private _deletedAt: Date;
   private _type: ConversationType;
   private _groupAvatar?: string;
+  private _lastMessageAt?: Date;
 
   constructor(props: ConversationProps) {
     this._id = props.id;
@@ -29,6 +31,7 @@ export class Conversation {
     this._deletedAt = props.deletedAt;
     this._type = props.type;
     this._groupAvatar = props.groupAvatar;
+    this._lastMessageAt = props.lastMessageAt;
   }
 
   get id(): string {
@@ -85,6 +88,14 @@ export class Conversation {
     this._groupAvatar = groupAvatar;
   }
 
+  get lastMessageAt(): Date | undefined {
+    return this._lastMessageAt;
+  }
+
+  set lastMessageAt(lastMessageAt: Date | undefined) {
+    this._lastMessageAt = lastMessageAt;
+  }
+
   static async create(
     userId: string,
     request: ICreateConversationRequestDTO
@@ -96,6 +107,7 @@ export class Conversation {
       isArchived: false,
       deletedAt: null,
       type: ConversationType.PRIVATE,
+      lastMessageAt: request.lastMessageAt || null,
     };
 
     return new Conversation(newConversation);

--- a/src/infrastructure/persistence/databases/mysql/prisma/migrations/20250514132025_add_last_message_at_column_to_conversation_table/migration.sql
+++ b/src/infrastructure/persistence/databases/mysql/prisma/migrations/20250514132025_add_last_message_at_column_to_conversation_table/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `conversation` ADD COLUMN `last_message_at` DATETIME(3) NULL;

--- a/src/infrastructure/persistence/databases/mysql/prisma/migrations/20250514140108_/migration.sql
+++ b/src/infrastructure/persistence/databases/mysql/prisma/migrations/20250514140108_/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[last_message_at,id]` on the table `Conversation` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX `Conversation_last_message_at_id_key` ON `Conversation`(`last_message_at`, `id`);

--- a/src/infrastructure/persistence/databases/mysql/prisma/schema.prisma
+++ b/src/infrastructure/persistence/databases/mysql/prisma/schema.prisma
@@ -134,15 +134,16 @@ model Message {
 }
 
 model Conversation {
-  id          String           @id @default(uuid())
-  title       String?
-  creatorId   String           @map("creator_id")
-  createdAt   DateTime         @default(now()) @map("created_at")
-  updatedAt   DateTime         @updatedAt @map("updated_at")
-  isArchived  Boolean          @default(false) @map("is_archived")
-  deletedAt   DateTime?        @map("deleted_at")
-  type        ConversationType @default(PRIVATE) @map("type")
-  groupAvatar String?          @map("group_avatar")
+  id            String           @id @default(uuid())
+  title         String?
+  creatorId     String           @map("creator_id")
+  createdAt     DateTime         @default(now()) @map("created_at")
+  updatedAt     DateTime         @updatedAt @map("updated_at")
+  isArchived    Boolean          @default(false) @map("is_archived")
+  deletedAt     DateTime?        @map("deleted_at")
+  type          ConversationType @default(PRIVATE) @map("type")
+  groupAvatar   String?          @map("group_avatar")
+  lastMessageAt DateTime?        @map("last_message_at")
 
   creator User @relation("Creator", fields: [creatorId], references: [id])
 

--- a/src/infrastructure/persistence/databases/mysql/prisma/schema.prisma
+++ b/src/infrastructure/persistence/databases/mysql/prisma/schema.prisma
@@ -150,6 +150,8 @@ model Conversation {
   conversationParticipants Participant[]
   deletedConversations     DeletedConversation[]
   messages                 Message[]
+
+  @@unique([lastMessageAt, id])
 }
 
 model Participant {

--- a/src/interfaces/graphql/DTOs/ConversationDTO.ts
+++ b/src/interfaces/graphql/DTOs/ConversationDTO.ts
@@ -32,6 +32,9 @@ export class ConversationDTO {
 
   @Field(() => ConversationType)
   type: ConversationType;
+
+  @Field(() => Date, { nullable: true })
+  lastMessageAt?: Date;
 }
 
 @ObjectType()

--- a/src/interfaces/graphql/mappers/ConversationMapper.ts
+++ b/src/interfaces/graphql/mappers/ConversationMapper.ts
@@ -29,6 +29,7 @@ export class ConversationMapper {
       type,
       groupAvatar,
       defaultGroupAvatar,
+      lastMessageAt,
     } = conversation;
 
     return {
@@ -40,6 +41,7 @@ export class ConversationMapper {
       isArchived,
       type,
       defaultGroupAvatar,
+      lastMessageAt,
       participants: participantDTOS.map(
         (participantDTO) =>
           new ExtendedParticipant(
@@ -62,8 +64,16 @@ export class ConversationMapper {
    * @returns The mapped Conversation entity.
    */
   static toEntity(conversationDTO: ExtendConversationDTO): Conversation {
-    const { id, title, creatorId, deletedAt, isArchived, type, groupAvatar } =
-      conversationDTO;
+    const {
+      id,
+      title,
+      creatorId,
+      deletedAt,
+      isArchived,
+      type,
+      groupAvatar,
+      lastMessageAt,
+    } = conversationDTO;
     return new Conversation({
       id,
       title,
@@ -72,6 +82,7 @@ export class ConversationMapper {
       deletedAt,
       isArchived,
       type,
+      lastMessageAt,
     });
   }
 }

--- a/src/scripts/migrateLastMessageAt.ts
+++ b/src/scripts/migrateLastMessageAt.ts
@@ -1,0 +1,47 @@
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+async function migrateLastMessageAt() {
+  try {
+    console.log("Starting migration for lastMessageAt...");
+
+    // Fetch all conversations
+    const conversations = await prisma.conversation.findMany({
+      include: {
+        messages: {
+          orderBy: {
+            createdAt: "desc",
+          },
+          take: 1, // Get the last message for each conversation
+        },
+      },
+    });
+
+    // Update each conversation's lastMessageAt field
+    for (const conversation of conversations) {
+      const lastMessage = conversation.messages[0];
+      if (lastMessage) {
+        await prisma.conversation.update({
+          where: { id: conversation.id },
+          data: { lastMessageAt: lastMessage.createdAt },
+        });
+        console.log(
+          `Updated conversation ${conversation.id} with lastMessageAt = ${lastMessage.createdAt}`
+        );
+      } else {
+        console.log(
+          `No messages found for conversation ${conversation.id}, skipping...`
+        );
+      }
+    }
+
+    console.log("Migration completed successfully!");
+  } catch (error) {
+    console.error("Error during migration:", error);
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+migrateLastMessageAt();


### PR DESCRIPTION
- Install `dayjs` package.
- Add column `lastMessageAt` column to the `conversation` table.
- Update logic when creating new message (updating `lastMessageAt` with the `createdAt` value of the new message).
- Update related files.
- Add the migration script to update the `lastMessageAt` value for all conversations.