### PR TITLE
Task #46: Modify cursor when getting my conversations

### DIFF
--- a/src/application/usecases/conversation/GetMyConversationsUseCase.ts
+++ b/src/application/usecases/conversation/GetMyConversationsUseCase.ts
@@ -81,7 +81,10 @@ class GetMyConversationsUseCase implements IGetMyConversationsUsecase {
         }
       );
 
-      return { data: { data: response }, error: null };
+      return {
+        data: { data: response, nextCursor: value.nextCursor },
+        error: null,
+      };
     } catch (error) {
       this.logger.error(error.message);
       return {

--- a/src/infrastructure/persistence/repositories/conversation/ConversationPrismaRepository.ts
+++ b/src/infrastructure/persistence/repositories/conversation/ConversationPrismaRepository.ts
@@ -133,7 +133,9 @@ class ConversationPrismaRepository implements IConversationRepository {
       });
 
       const nextCursor =
-        conversations.length > limit ? conversations[limit].id : undefined;
+        conversations.length > limit
+          ? conversations[limit].lastMessageAt.toISOString()
+          : undefined;
 
       return {
         value: {

--- a/src/shared/responses/CursorPagePaginationResponse.ts
+++ b/src/shared/responses/CursorPagePaginationResponse.ts
@@ -1,0 +1,16 @@
+import { ObjectType, Field, ClassType } from "type-graphql";
+
+export function CursorBasedPaginationDTO<TItem extends ClassType>(
+  TItemClass: TItem
+) {
+  @ObjectType()
+  abstract class PaginationDTO {
+    @Field(() => [TItemClass])
+    items: InstanceType<TItem>[];
+
+    @Field(() => String, { nullable: true })
+    nextCursor?: string;
+  }
+
+  return PaginationDTO;
+}

--- a/src/shared/responses/GlobalResponse.ts
+++ b/src/shared/responses/GlobalResponse.ts
@@ -30,16 +30,6 @@ export function GlobalResponse<T, IsArray extends boolean = false>(
   @ObjectType({ implements: IResponse })
   abstract class Response extends IResponse {
     /**
-     * The HTTP status code (optional).
-     */
-    statusCode?: number;
-
-    /**
-     * A message associated with the response (optional).
-     */
-    message?: string;
-
-    /**
      * The data associated with the response (optional).
      */
     @Field(() => (isArray ? [TClass] : TClass), { nullable: true })
@@ -54,3 +44,4 @@ export function GlobalResponse<T, IsArray extends boolean = false>(
 
   return Response;
 }
+

--- a/src/shared/responses/index.ts
+++ b/src/shared/responses/index.ts
@@ -1,3 +1,4 @@
 export * from "./GlobalResponse";
 export * from "./UseCaseResponse";
 export * from "./RepositoryResponse";
+export * from "./CursorPagePaginationResponse";


### PR DESCRIPTION
- Create a shared response for **cursor-based pagination** response.
- Update cursor when querying latest conversations: from `id` to `lastMessageAt`.
- Update related files that impacted by changes.